### PR TITLE
Set the minimum git version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To install git visit [here](https://git-scm.com/book/en/v2/Getting-Started-Insta
     ...
 ```
 
-## Fetch new updates via a trigger channel
+## Fetch new updates via a signal channel
 - The one hour interval at which the update signal is sent starts to count immediately
 after the `proposals.NewParser(repoOwner, repoName, cloneDir)` is invoked.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Check out the full doc at [godoc.org](https://godoc.org/github.com/dmigwi/go-pip
 - [Import go-piparser](#import-go-piparser)
 - [Initialize the Parser instance](#initialize-the-parser-instance)
 - [Fetch the Proposal's Votes](#fetch-the-proposal's-votes)
+- [Fetch new updates via a trigger channel](#fetch-new-updates-via-a-trigger-channel)
 - [Full Sample Program](#full-sample-program)
 - [Test Client](#test-client)
 
@@ -26,6 +27,8 @@ Check out the full doc at [godoc.org](https://godoc.org/github.com/dmigwi/go-pip
 
 - git -  The tool requires a functional git commandline installation.
 To install git visit [here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+
+    - A git version of `v1.5.1` released on [April 4th 2007](https://github.com/git/git/releases/tag/v1.5.1) or later is needed.
 
 ## Installation
 
@@ -46,13 +49,7 @@ To install git visit [here](https://git-scm.com/book/en/v2/Getting-Started-Insta
     repoName  := ""
     cloneDir  := "/path/to/root/clone/directory"
 
-    handler := func() {
-		// Invoked hourly to trigger retrieval of the newly fetched updates.
-		// Fetch the new Updates by including the timestamp when the last
-		// update was queried for given proposal token.
-	}
-
-    parser, err := proposals.NewParser(repoOwner, repoName, cloneDir, handler)
+    parser, err := proposals.NewParser(repoOwner, repoName, cloneDir)
     if err != nil {
 		log.Fatalf("unexpected error occured: %v", err)
     }
@@ -61,7 +58,6 @@ To install git visit [here](https://git-scm.com/book/en/v2/Getting-Started-Insta
 - `repoOwner` - defines the owner of the repository where the Politeia votes are to be queries from. If not set, it defaults to `decred-proposals`
 - `repoName` - defines the name of the repository holding the Politeia votes. If not set, it defaults to `mainnet`.
 - `cloneDir` - defines the directory where the said repository will be cloned into. If not set, a tmp folder is created and set.
-- `handler` - defines the function that is invoked to trigger the client updates fetch immediately after the parser tool retrieves them.
 
 ## Fetch the Proposal's Votes
 
@@ -77,6 +73,29 @@ To install git visit [here](https://git-scm.com/book/en/v2/Getting-Started-Insta
     }
     
     ...
+```
+
+## Fetch new updates via a trigger channel
+- The one hour interval at which the update signal is sent starts to count immediately
+after the `proposals.NewParser(repoOwner, repoName, cloneDir)` is invoked.
+
+```go
+    // Updates trigger signal is sent hourly after which retrieval of the newly
+    // fetched updates can commence.
+    proposalUpdatesSignal := parser.UpdateSignal()
+    for range  proposalUpdatesSignal{
+        // set the since time value
+        since, err := time.Parse(time.RFC3339,"2019-03-05T00:59:18Z")
+        if err != nil {
+            log.Fatalf("unexpected error occured: %v", err)
+        }
+
+        // Fetch the proposal updates since 2019-03-05T00:59:18Z.
+        data, err = parser.ProposalHistorySince(proposalToken, since)
+        if err != nil {
+            log.Fatalf("unexpected error occured: %v", err)
+        }
+    }
 ```
 
 ## Full Sample Program
@@ -96,15 +115,8 @@ To install git visit [here](https://git-scm.com/book/en/v2/Getting-Started-Insta
          // Set the Proposal token
         proposalToken := "60adb9c0946482492889e85e9bce05c309665b3438dd85cb1a837df31fbf57fb"
 
-        // notifyChan will signal when updates are available.
-        notifyChan := make(chan struct{})
-
-        handler := func() {
-            notifyChan <- struct{}{}
-        }
-
         // Create a new Parser instance
-        parser, err := proposals.NewParser("", "", cloneDir, handler)
+        parser, err := proposals.NewParser("", "", cloneDir)
         if err != nil {
             log.Fatalf("unexpected error occured: %v", err)
         }
@@ -118,15 +130,15 @@ To install git visit [here](https://git-scm.com/book/en/v2/Getting-Started-Insta
         ...
 
         // Retrieve proposal updates after they happen.
-        for range notifyChan {
+        proposalUpdatesSignal := parser.UpdateSignal()
+        for range  proposalUpdatesSignal{
             // set the since time value
             since, err := time.Parse(time.RFC3339,"2019-03-05T00:59:18Z")
             if err != nil {
                 log.Fatalf("unexpected error occured: %v", err)
             }
 
-            // Fetch the proposal since 2019-03-05T00:59:18Z in when 1hr the
-            // interval(update) is over.
+            // Fetch the proposal updates since 2019-03-05T00:59:18Z.
             data, err = parser.ProposalHistorySince(proposalToken, since)
             if err != nil {
                 log.Fatalf("unexpected error occured: %v", err)

--- a/proposals/parser_test.go
+++ b/proposals/parser_test.go
@@ -49,11 +49,9 @@ func TestNewParser(t *testing.T) {
 		{testROwnerWSpaces, testRepoWSpaces, invalidPath},
 	}
 
-	handler := func() {}
-
 	for i, val := range td {
 		t.Run("Test_#"+strconv.Itoa(i), func(t *testing.T) {
-			p, err := NewParser(val.repoOwner, val.repo, val.dir, handler)
+			p, err := NewParser(val.repoOwner, val.repo, val.dir)
 			if err != nil {
 				t.Fatalf("expected no error but found: %v", err)
 			}

--- a/proposals/types/regex_test.go
+++ b/proposals/types/regex_test.go
@@ -402,3 +402,39 @@ func TestRetrieveProposalToken(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGitVersionSupported(t *testing.T) {
+	type testData struct {
+		ParsedStr string
+		IsError   bool
+	}
+
+	td := []testData{
+		{"..1", true},
+		{"2..1", true},
+		{"0.9.1", true},
+		{"1.9.1", false},
+		{"100.0.1", false},
+		{"10.0.0", false},
+		{"git version 1.1.1", true},
+		{"git version 1.4.1", true},
+		{"git version 1.6.1", false},
+		{"git version 2.4.1", false},
+		{"git version 2.7.1", false},
+		{"git version 2.19.1", false},
+	}
+
+	for i, val := range td {
+		t.Run("Test_#"+strconv.Itoa(i), func(t *testing.T) {
+			err := IsGitVersionSupported(val.ParsedStr)
+
+			if err != nil && !val.IsError {
+				t.Fatalf("expected no error but found %v:", err)
+			}
+
+			if err == nil && val.IsError {
+				t.Fatal("expected an error but found none")
+			}
+		})
+	}
+}

--- a/proposals/types/types.go
+++ b/proposals/types/types.go
@@ -7,6 +7,7 @@ package types
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -34,6 +35,27 @@ const (
 )
 
 var proposalToken string
+
+// semVer defines the semantic version structure.
+type semVer struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// minGitVersion defines the minimum supported git version. This version
+// allows git log -p --reverse to be run. Here are the release notes:
+// https://github.com/git/git/blob/53f9a3e157dbbc901a02ac2c73346d375e24978c/Documentation/RelNotes/1.5.1.txt
+var minGitVersion = semVer{1, 5, 1}
+
+// ErrGitVersion is the default error returned if an invalid git version was found.
+var ErrGitVersion = errors.New("invalid git version found. A minimum of v" +
+	minGitVersion.String() + " was expected")
+
+// String() is the default stringer for the semVer data type.
+func (s semVer) String() string {
+	return fmt.Sprintf("%d.%d.%d", s.Major, s.Minor, s.Patch)
+}
 
 // Confirm that Votes implements the unmarshalling interface.
 var _ json.Unmarshaler = (*Votes)(nil)

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -4,6 +4,7 @@ This is a http server that parses and serves data of the proposal token set on t
 
 
 ## Check the git version to confirm its installation
+- A minimum git version of `v1.5.1` released on [April 4th 2007](https://github.com/git/git/releases/tag/v1.5.1) is needed.
 
 ```bash
     git --version

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -7,20 +7,20 @@ This is a http server that parses and serves data of the proposal token set on t
 - A minimum git version of `v1.5.1` released on [April 4th 2007](https://github.com/git/git/releases/tag/v1.5.1) is needed.
 
 ```bash
-    git --version
+    $ git --version
 ```
 
 ## Clone this repository
 
 ```bash
-    git clone https://github.com/dmigwi/go-piparser.git
+    $ git clone https://github.com/dmigwi/go-piparser.git
 ```
 
 ## Create the tool clone directory
 - For unix based o.s.
 
 ```bash
-    mkdir -p ~/playground
+    $ mkdir -p ~/playground
 ```
 - For windows
 ```bash
@@ -30,7 +30,7 @@ This is a http server that parses and serves data of the proposal token set on t
 ## Start Server
 
 ```bash
-    cd go-piparser/testutil
+    $ cd go-piparser/testutil
 
     $ go build . && ./testutil
     2019/03/05 11:44:09 Setting up the environment. Please Wait...

--- a/testutil/main.go
+++ b/testutil/main.go
@@ -109,12 +109,7 @@ func main() {
 
 	log.Println("Setting up the environment. Please Wait...")
 
-	handler := func() {
-		// since this testutil does not store data, this handler implementation
-		// is not necessary.
-	}
-
-	parser, err = proposals.NewParser("", "", cloneDir, handler)
+	parser, err = proposals.NewParser("", "", cloneDir)
 	if err != nil {
 		log.Printf("unexpected error occured: %v", err)
 		return


### PR DESCRIPTION
- This tool requires a minimum git version of 1.5.1 that was released on [April 4th 2007](https://github.com/git/git/releases/tag/v1.5.1). Here are the [release notes](https://github.com/git/git/blob/53f9a3e157dbbc901a02ac2c73346d375e24978c/Documentation/RelNotes/1.5.1.txt)

- `UpdateSignal() chan<- struct{}` method has been added to decouple some updates process from the `NewParser` constructor.

- `TriggerUpdates() error` is fail safe method has been added to trigger github updates fetch anytime without waiting for the default hourly fetch.